### PR TITLE
Add Telegram bot skeleton for FanPay listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
+# Telegram FanPay Listing Bot
 
+Этот проект предоставляет Telegram-бота, который собирает данные лота у пользователя и создаёт объявление на FanPay, используя авторизационные cookie вашего аккаунта.
+
+## Возможности
+
+- Пошаговое общение в Telegram: бот спрашивает название, описание, цену и количество.
+- Проверка введённых данных и подтверждение перед созданием лота.
+- Отправка запроса на FanPay с использованием заранее сохранённого cookie-файла.
+
+## Предварительные требования
+
+1. Python 3.10+
+2. Токен Telegram-бота
+3. Cookie-файл сессии FanPay в формате Netscape (его можно экспортировать, например, через расширение EditThisCookie)
+
+## Установка
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Переменные окружения
+
+- `TELEGRAM_BOT_TOKEN` — токен вашего Telegram-бота
+- `FANPAY_COOKIE_FILE` — путь к cookie-файлу FanPay
+- `FANPAY_BASE_URL` (опционально) — если нужно переопределить базовый URL (по умолчанию `https://funpay.com`)
+
+## Запуск
+
+```bash
+export TELEGRAM_BOT_TOKEN="<ваш токен>"
+export FANPAY_COOKIE_FILE="/path/to/cookies.txt"
+python -m bot.telegram_bot
+```
+
+## Настройка FanPay
+
+API FanPay не задокументирован, поэтому в файле `bot/fanpay.py` реализован базовый POST-запрос на эндпоинт `/api/listings`. Если на FanPay используется другой URL или требуется дополнительный CSRF-токен, обновите метод `create_listing` в соответствии с фактическим API.
+
+## Лицензия
+
+Проект распространяется по лицензии MIT.

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,1 @@
+"""Telegram FanPay bot package."""

--- a/bot/fanpay.py
+++ b/bot/fanpay.py
@@ -1,0 +1,114 @@
+"""FanPay client abstraction for creating listings via HTTP requests."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional, Union
+
+import requests
+
+
+class FanPayError(Exception):
+    """Raised when FanPay returns an unexpected response."""
+
+
+@dataclass
+class Listing:
+    """Simple data holder for a FanPay listing."""
+
+    name: str
+    description: str
+    price: float
+    quantity: int
+
+
+class FanPayClient:
+    """HTTP client that reuses a cookie jar to authenticate with FanPay.
+
+    The actual FanPay API is not publicly documented. This client focuses on
+    the pieces that are known to be required for creating a listing: an
+    authenticated session (expressed as a cookie jar) and CSRF token.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "https://funpay.com",
+        *,
+        cookie_file: Optional[Union[str, Path]] = None,
+        extra_headers: Optional[Mapping[str, str]] = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.session = session or requests.Session()
+        if cookie_file is not None:
+            self._load_cookies(cookie_file)
+        self.session.headers.setdefault("User-Agent", "FanPayBot/1.0")
+        self.session.headers.setdefault("Accept", "application/json")
+        if extra_headers:
+            self.session.headers.update(extra_headers)
+
+    # ------------------------------------------------------------------
+    # Cookie helpers
+    # ------------------------------------------------------------------
+    def _load_cookies(self, cookie_file: Union[str, Path]) -> None:
+        """Load cookies from a Netscape formatted file."""
+        jar = requests.cookies.RequestsCookieJar()
+        content = Path(cookie_file).read_text(encoding="utf-8")
+        for line in content.splitlines():
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) != 7:
+                continue
+            domain, flag, path, secure, expiration, name, value = parts
+            jar.set(
+                name,
+                value,
+                domain=domain,
+                path=path,
+                secure=secure.upper() == "TRUE",
+            )
+        self.session.cookies.update(jar)
+
+    # ------------------------------------------------------------------
+    # API operations
+    # ------------------------------------------------------------------
+    def create_listing(self, listing: Listing, csrf_token: Optional[str] = None) -> dict:
+        """Create a FanPay listing.
+
+        Parameters
+        ----------
+        listing:
+            Listing data provided by the user.
+        csrf_token:
+            Optional CSRF token. When ``None`` the method attempts to reuse
+            the value already stored in the session cookies.
+
+        Returns
+        -------
+        dict
+            Parsed JSON response for further processing.
+        """
+
+        payload = {
+            "title": listing.name,
+            "description": listing.description,
+            "price": listing.price,
+            "quantity": listing.quantity,
+        }
+
+        headers = {}
+        token = csrf_token or self.session.cookies.get("csrftoken")
+        if token:
+            headers["X-CSRFToken"] = token
+
+        url = f"{self.base_url}/api/listings"
+        response = self.session.post(url, json=payload, headers=headers, timeout=30)
+        if response.status_code >= 400:
+            raise FanPayError(
+                f"FanPay error {response.status_code}: {response.text}".strip()
+            )
+        try:
+            return response.json()
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise FanPayError("FanPay returned invalid JSON response") from exc

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -1,0 +1,174 @@
+"""Telegram bot that collects listing data and creates a FanPay listing."""
+from __future__ import annotations
+
+import logging
+import os
+from decimal import Decimal, InvalidOperation
+
+from telegram import ReplyKeyboardMarkup, ReplyKeyboardRemove, Update
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+    ConversationHandler,
+    MessageHandler,
+    filters,
+)
+
+from .fanpay import FanPayClient, FanPayError, Listing
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+NAME, DESCRIPTION, PRICE, QUANTITY, CONFIRM = range(5)
+
+
+def _build_application(token: str) -> Application:
+    return Application.builder().token(token).build()
+
+
+def start_factory(token: str, fanpay_client: FanPayClient) -> Application:
+    """Create and configure the Telegram application instance."""
+
+    app = _build_application(token)
+
+    async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        await update.message.reply_text(
+            "Здравствуйте! Отправьте название нового лота.",
+            reply_markup=ReplyKeyboardRemove(),
+        )
+        return NAME
+
+    async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        await update.message.reply_text(
+            "Создание лота отменено.", reply_markup=ReplyKeyboardRemove()
+        )
+        return ConversationHandler.END
+
+    async def ask_description(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        context.user_data["name"] = update.message.text.strip()
+        await update.message.reply_text("Введите описание лота.")
+        return DESCRIPTION
+
+    async def ask_price(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        context.user_data["description"] = update.message.text.strip()
+        await update.message.reply_text("Введите цену в рублях (например, 150.00).")
+        return PRICE
+
+    async def ask_quantity(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        try:
+            price = Decimal(update.message.text.replace(",", ".").strip())
+        except (InvalidOperation, AttributeError):
+            await update.message.reply_text(
+                "Не удалось распознать цену. Попробуйте еще раз, например 150 или 150.00."
+            )
+            return PRICE
+
+        if price <= 0:
+            await update.message.reply_text(
+                "Цена должна быть больше нуля. Попробуйте еще раз."
+            )
+            return PRICE
+
+        context.user_data["price"] = float(price)
+        await update.message.reply_text("Введите количество товара (целое число).")
+        return QUANTITY
+
+    async def confirm(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        try:
+            qty = int(update.message.text.strip())
+        except (ValueError, AttributeError):
+            await update.message.reply_text(
+                "Количество должно быть целым числом. Попробуйте снова."
+            )
+            return QUANTITY
+
+        if qty <= 0:
+            await update.message.reply_text(
+                "Количество должно быть положительным. Попробуйте снова."
+            )
+            return QUANTITY
+
+        context.user_data["quantity"] = qty
+        summary = (
+            f"Название: {context.user_data['name']}\n"
+            f"Описание: {context.user_data['description']}\n"
+            f"Цена: {context.user_data['price']}\n"
+            f"Количество: {context.user_data['quantity']}\n\n"
+            "Создать лот?"
+        )
+        await update.message.reply_text(
+            summary,
+            reply_markup=ReplyKeyboardMarkup(
+                [["Да"], ["Нет"]], one_time_keyboard=True, resize_keyboard=True
+            ),
+        )
+        return CONFIRM
+
+    async def create_listing(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        answer = update.message.text.strip().lower()
+        if answer not in {"да", "yes"}:
+            await update.message.reply_text(
+                "Создание лота отменено.", reply_markup=ReplyKeyboardRemove()
+            )
+            return ConversationHandler.END
+
+        listing = Listing(
+            name=context.user_data["name"],
+            description=context.user_data["description"],
+            price=context.user_data["price"],
+            quantity=context.user_data["quantity"],
+        )
+        try:
+            response = fanpay_client.create_listing(listing)
+        except FanPayError as exc:
+            logger.exception("Failed to create FanPay listing")
+            await update.message.reply_text(
+                f"Не удалось создать лот: {exc}", reply_markup=ReplyKeyboardRemove()
+            )
+            return ConversationHandler.END
+
+        await update.message.reply_text(
+            "Лот успешно создан на FanPay!",
+            reply_markup=ReplyKeyboardRemove(),
+        )
+        await update.message.reply_text(f"Ответ FanPay: {response}")
+        return ConversationHandler.END
+
+    conv_handler = ConversationHandler(
+        entry_points=[CommandHandler("start", start)],
+        states={
+            NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, ask_description)],
+            DESCRIPTION: [MessageHandler(filters.TEXT & ~filters.COMMAND, ask_price)],
+            PRICE: [MessageHandler(filters.TEXT & ~filters.COMMAND, ask_quantity)],
+            QUANTITY: [MessageHandler(filters.TEXT & ~filters.COMMAND, confirm)],
+            CONFIRM: [MessageHandler(filters.TEXT & ~filters.COMMAND, create_listing)],
+        },
+        fallbacks=[CommandHandler("cancel", cancel)],
+    )
+
+    app.add_handler(conv_handler)
+    app.add_handler(CommandHandler("cancel", cancel))
+    return app
+
+
+def main() -> None:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    cookie_path = os.environ.get("FANPAY_COOKIE_FILE")
+
+    if not token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN environment variable is required")
+    if not cookie_path:
+        raise RuntimeError("FANPAY_COOKIE_FILE environment variable is required")
+
+    base_url = os.environ.get("FANPAY_BASE_URL", "https://funpay.com")
+    fanpay_client = FanPayClient(
+        base_url=base_url,
+        cookie_file=os.fspath(cookie_path),
+    )
+    application = start_factory(token, fanpay_client)
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot>=20.4
+requests>=2.31


### PR DESCRIPTION
## Summary
- add a reusable FanPay client that authenticates via cookies and posts listing data
- implement a Telegram conversation bot that collects listing details and sends them to FanPay
- document setup instructions and dependencies, including requirements and gitignore entries

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d82a2a0e988333a95bf99a5190c750